### PR TITLE
apply mask after patchValue

### DIFF
--- a/src/mask/mask.directive.ts
+++ b/src/mask/mask.directive.ts
@@ -38,7 +38,7 @@ export class MaskDirective extends MaskBaseDirective implements ControlValueAcce
       if (autocorrected === '' && !this._mask.settings.allowIncomplete)
         this.setText('');
       else {
-        // Маска верна, но нужно автокоррекцию провернуть        
+        // Маска верна, но нужно автокоррекцию провернуть
         if (autocorrected != this._txtValue)
           this.setText(autocorrected);
       }
@@ -77,6 +77,12 @@ export class MaskDirective extends MaskBaseDirective implements ControlValueAcce
 
       // Но обновить состояние нужно...
       this.updateState();
+
+      let autocorrected = this._mask.applyMask(this._txtValue);
+      if (autocorrected !== '' || this._mask.settings.allowIncomplete) {
+        if (autocorrected != this._txtValue)
+          this.setText(autocorrected);
+      }
     }
 
     @Input("yn-mask")


### PR DESCRIPTION
Исходные данные: допустим, есть поле с шестизнаком. В маске разделяем дефисом: NNN-NNN.
Когда мы печатаем 123456, всё ок, если откуда-то копируем "123456", то первоначально (об этом будет ишью) всё ок, маска срабатывает.
Но если мы делаем используем реактивную форму, выполняя patchValue('123456'), то маска не срабатывает. Фокус и блюр по инпуту заставляют маску иницилизироваться.
В данном реквесте я по сути взял кусок кода из метода blur() и добавил его в writeValue, что задачу решает, но может как автор предложишь вариант получше.